### PR TITLE
Update go.mod to reference 1.23

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/unitvectory-labs/clip4llm
 
-go 1.23.1
+go 1.23
 
 require github.com/atotto/clipboard v0.1.4


### PR DESCRIPTION
Not referencing the minor version anymore