### PR TITLE
Fix module name casing in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/unitvectory-labs/clip4llm
+module github.com/UnitVectorY-Labs/clip4llm
 
 go 1.23.5
 


### PR DESCRIPTION
Correcting the case so it matches the GitHub org name.